### PR TITLE
fix: tree-view active init

### DIFF
--- a/packages/playground/src/pages/TreeView.vue
+++ b/packages/playground/src/pages/TreeView.vue
@@ -37,18 +37,44 @@ const groups = ref([
     ],
   },
 ]);
-const activeGroups = ref(["1-1", "1-3"]);
-const selected = ref(["2", "1-1"]);
+
+const active0 = ref(["1-1"]);
+const opened0 = ref([]);
+const search0 = ref('');
+
 const opened = ref([]);
 const search = ref("");
+const activeGroups = ref(["1-1", "1-3"]);
+const selected = ref(["2", "1-1"]);
 
 const opened2 = ref([]);
 const active2 = ref([]);
 const search2 = ref('');
+
+setTimeout(() => {
+  active0.value = ["2"]
+}, 3000)
 </script>
 
 <template>
   <section class="d-flex pa-2" style="gap: 8px">
+    <y-card class="pa-4 ma-1" style="width: 320px">
+      <y-field-input
+        v-model="search0"
+        clearable
+        ceramic
+        class="mb-2"
+      ></y-field-input>
+      <y-tree-view
+        v-model:expanded="opened0"
+        v-model:active="active0"
+        :items="groups"
+        :search="search0"
+        enable-active
+        required-active
+      ></y-tree-view>
+    </y-card>
+
     <y-card class="pa-4 ma-1" style="width: 320px">
       <y-field-input
         v-model="search"
@@ -92,6 +118,7 @@ const search2 = ref('');
           default-expand="0"
       ></y-tree-view>
     </y-card>
+
   </section>
 </template>
 

--- a/packages/yuyeon/package.json
+++ b/packages/yuyeon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yuyeon",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "keywords": [
     "UI Library",
     "Vue"

--- a/packages/yuyeon/src/components/tree-view/YTreeView.tsx
+++ b/packages/yuyeon/src/components/tree-view/YTreeView.tsx
@@ -235,6 +235,7 @@ export const YTreeView = defineComponent({
       if (to) {
         activeSet.value.add(key);
         node.active = true;
+        issueVnodeState(key);
       } else {
         if (
           props.requiredActive &&
@@ -369,12 +370,16 @@ export const YTreeView = defineComponent({
 
         // init
         const oldSelected = [...selectedSet.value];
+        const oldActive = [...activeSet.value];
         selectedSet.value.clear();
         expandedSet.value.clear();
         activeSet.value.clear();
         updateNodes(neo);
         if (!deepEqual(oldSelected, [...selectedSet.value])) {
           emitSelected();
+        }
+        if (!deepEqual(oldActive, [...activeSet.value])) {
+          emitActive();
         }
       },
       { deep: true },
@@ -449,7 +454,7 @@ export const YTreeView = defineComponent({
     });
 
     onMounted(() => {
-      if (props.defaultExpand !== undefined) {
+      if (props.defaultExpand != null && props.defaultExpand !== false) {
         expandedCache.value = [...expand(props.defaultExpand)];
       } else {
         expanded.value.forEach((v: any) => updateExpanded(getNodeKey(v), true));

--- a/packages/yuyeon/src/components/tree-view/YTreeViewNode.ts
+++ b/packages/yuyeon/src/components/tree-view/YTreeViewNode.ts
@@ -5,7 +5,7 @@ import {
   defineComponent,
   h,
   inject,
-  ref,
+  ref, onBeforeMount, getCurrentInstance,
 } from 'vue';
 
 import { pressItemsPropsOptions } from '../../abstract/items';
@@ -57,6 +57,7 @@ export const YTreeViewNode = defineComponent({
     ...pressYTreeViewNodeProps(),
   },
   setup(props, { slots, expose }) {
+    const vm = getCurrentInstance();
     const treeView = inject<any>('tree-view');
 
     const expanded = ref(false);
@@ -259,6 +260,10 @@ export const YTreeViewNode = defineComponent({
       immediate,
     });
 
+    onBeforeMount(() => {
+      treeView?.register?.(myKey.value, vm!.exposed);
+    });
+
     return {
       treeView,
       myKey,
@@ -267,9 +272,6 @@ export const YTreeViewNode = defineComponent({
       selected,
       immediate,
     };
-  },
-  created() {
-    this.treeView?.register?.(this.myKey, this);
   },
 });
 


### PR DESCRIPTION
fix: Change the exposed bindings because the lifecycle has changed to onBeforeMount where you register the tree-view-node